### PR TITLE
Add option to skip mask sites in VCF

### DIFF
--- a/src/read_vcf.py
+++ b/src/read_vcf.py
@@ -12,6 +12,7 @@ def print_samples_to_vcf(
     ploidy,
     out_file,
     site_mask=None,
+    exclude_mask_sites=False,
     exclude_monoallelic_sites=False,
     contig_id=None,
 ):
@@ -36,6 +37,7 @@ def print_samples_to_vcf(
     :param tsinfer.SampleData sd: Samples.
     :param int ploidy: 1 or 2.
     :param array_like site_mask: Site positions to mask (1-based).
+    :param bool exclude_mask_sites: Exclude masked sites.
     :param bool exclude_monoallelic_sites: Exclude monoallelic sites.
     :param str contig_id: Contig name.
     :param click.Path out_file: Path to output VCF file.
@@ -83,6 +85,8 @@ def print_samples_to_vcf(
                     continue
 
             if site_mask is not None and POS in site_mask:
+                if exclude_mask_sites:
+                    continue
                 missing_gt = '.' if ploidy == 1 else '.|.'
                 gt = np.repeat(missing_gt, sd.num_individuals)
             else:


### PR DESCRIPTION
BEAGLE 4.1 does not take monoallelic sites, so this option is useful.