### PR TITLE
Fix bug

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -82,7 +82,7 @@ def make_compatible_samples(
             else:
                 metadata = ind.metadata
             new_sd.add_individual(
-                ploidy=len(ind.nodes),
+                ploidy=len(ind.samples),
                 metadata=metadata,
             )
 


### PR DESCRIPTION
`ind.nodes` is in `tskit.TreeSequence` objects, not `tsinfer.SampleData`.