### PR TITLE
Fix bug in convert.py where the last entry in a VCF file is not processed

### DIFF
--- a/src/convert.py
+++ b/src/convert.py
@@ -220,12 +220,9 @@ def filter_duplicates_target(vcf, target_sites_pos=None):
     are present in the target sampledata file.
     """
     if target_sites_pos is not None:
-
         def site_in_target(site):
             return site in target_sites_pos
-
     else:
-
         def site_in_target(site):
             return True
 
@@ -241,7 +238,7 @@ def filter_duplicates_target(vcf, target_sites_pos=None):
             elif bad_pos != next_row.POS:
                 bad_pos = -1
         row = next_row
-    if row is not None and bad_pos != -1 and site_in_target(row.POS):
+    if row is not None and bad_pos == -1 and site_in_target(row.POS):
         yield row
 
 


### PR DESCRIPTION
Originally taken from https://github.com/awohns/unified_genealogy_paper/blob/51dc9130275ec93dfeba83bb3d31cf27d95e2dbb/all-data/convert.py#L192

In a test run, even when all the site positions are unique, the last entry is not included in the samples. By changing the `bad_pos != -1` to `bad_pos == 1`, the last entry is processed into samples.
