### PR TITLE
Fix bug where data type int8 is too small, leading to overflow

### DIFF
--- a/src/impute_by_sample_matching.py
+++ b/src/impute_by_sample_matching.py
@@ -145,7 +145,7 @@ def prepare_input_matrix(ref_ts, target_ds):
     H1 = np.full(
         (num_sites, num_samples),
         tskit.MISSING_DATA,
-        dtype=np.int8
+        dtype=np.int64
     )
 
     i = 0


### PR DESCRIPTION
`H1` in `prepare_input_matrix` is now set to `np.int64`.